### PR TITLE
Fix default reducer resetting state on every action

### DIFF
--- a/src/SagaTester.js
+++ b/src/SagaTester.js
@@ -36,11 +36,11 @@ export default class SagaIntegrationTester {
 
                 // TODO: update this to use `.isImmutable()` as soon as v4 is released.
                 // http://facebook.github.io/immutable-js/docs/#/isImmutable
-                if (initialState.toJS) {
-                    return initialState.mergeDeep(stateUpdate);
+                if (state.toJS) {
+                    return state.mergeDeep(stateUpdate);
                 }
 
-                return Object.assign({}, initialState, stateUpdate);
+                return Object.assign({}, state, stateUpdate);
             }
 
           // otherwise use the provided reducer


### PR DESCRIPTION
The default reducer uses `initialState` when it should be using `state`, which causes all state changes to be lost.